### PR TITLE
Adding init() function to keep history buttons if the application is reloaded

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -70,14 +70,15 @@
   #buttons-div {
       display: flex;
       flex-wrap: wrap;
-      justify-content: flex-start;
+      justify-content: center;
       align-content: flex-start;
       gap: 5px;
+      margin-top: 5px;
+      margin-bottom: 5px;
   }
 
   .history-btns {
       flex: 0 0 45%;
-      border: solid 1px black;
       background-color: lightgreen;
       border-radius: 5px;
       height: 30px;
@@ -88,3 +89,7 @@
       background-color: lime;
       cursor: pointer;
   }
+
+  .history-btns:active {
+    box-shadow: 0px 0px 10px 5px deepskyblue;
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -9,6 +9,8 @@ var covidDeathsEl = document.getElementById("covid-deaths");
 var mapiDiv = document.getElementById("mapi");
 var buttonsDivEl = document.getElementById("buttons-div");
 
+init();
+
 //initial values from Mexico
 var lat = 23;
 var lng = -102;
@@ -208,5 +210,29 @@ function renderHistoryBtns () {
     if (lastSearch.length > 6) {
         buttonsDivEl.removeChild(buttonsDivEl.children[6]);
     }
+}
 
+function init() {
+    loadHistoryBtns();
+}
+
+function loadHistoryBtns() {
+
+    var lastSearch = JSON.parse(localStorage.getItem("countries"));
+
+    if (lastSearch !== null) {
+        for (var i = 0; i < 6; i++) {
+            var newBtn = document.createElement("button");
+            newBtn.setAttribute("class", "history-btns");
+            newBtn.setAttribute("value", lastSearch[i]);
+            newBtn.textContent = lastSearch[i];
+            buttonsDivEl.appendChild(newBtn);
+            var btnValue = newBtn.getAttribute("value");
+            if (btnValue === "undefined") {
+                newBtn.setAttribute("style", "display: none");
+            }
+        }
+    } else {
+        return;
+    } 
 }


### PR DESCRIPTION
Adding init() function with localStorage.getItem to keep history buttons if the application is reloaded. Adding code to prevent the generation of empty buttons. I also added some more CSS style to the buttons if they are activated.